### PR TITLE
Modernize site styling with Doks-inspired theme

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,8 @@
         {% assign url = site.url | append: site.baseurl | append: page.url %}
     {% endif %}
     <meta name="description" content="{{ desc }}">
-    <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+    <meta name="theme-color" content="#253951">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700|Noto+Sans:400,700&display=swap" rel="stylesheet" type="text/css">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS" href="/feed.xml" />
     <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
     <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
@@ -55,9 +56,9 @@
                     {% endif %}
                 {% endfor %}
                 {% if page.lang == "en" %}
-                    <li class="alignable pull-left nav-list"><a class="lang" style="color: black" href="/">FR</a>
+                    <li class="alignable pull-left nav-list"><a class="lang" href="/">FR</a>
                 {% else %}
-                    <li class="alignable pull-left nav-list"><a class="lang" style="color: black" href="/en/about">EN</a>
+                    <li class="alignable pull-left nav-list"><a class="lang" href="/en/about">EN</a>
                 {% endif %}
                             </li>
             </ul>

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -11,9 +11,13 @@ html {
 }
 body {
     margin: 0;
-    font-family: "Lato";
+    font-family: "Noto Sans", sans-serif;
     height: auto;
     padding-bottom: 50px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: "Montserrat", sans-serif;
 }
 
 #particles-js canvas {
@@ -54,17 +58,27 @@ hr {
 
 #author-name {
     font-size: 30px;
-    color: #272727;
+    color: #fff;
     display: inline-block;
 }
 .navbar {
-    padding: 50px 0 50px 0;
+    background-color: $accent;
+    padding: 20px 0;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 .navbar-ul {
     display: inline-block;
     margin: 0;
     padding: 5px 0 5px 0;
     margin-left: 20px;
+}
+.navbar-ul a {
+    color: #fff;
+    text-decoration: none;
+}
+.navbar-ul a:hover {
+    opacity: 0.8;
+    text-decoration: none;
 }
 .nav-list {
     list-style-type: none;
@@ -89,9 +103,9 @@ hr {
     margin: auto;
 }
 .containernavbar {
-    background-color: #FFFFFF;
-    max-width: $max-width;
-    margin: auto;
+    background-color: $accent;
+    width: 100%;
+    margin: 0;
     z-index: 0;
 }
 .wrapper {

--- a/_sass/vars.scss
+++ b/_sass/vars.scss
@@ -2,7 +2,7 @@
  * Customization Variables
  */
 
-$accent: #318CE7;
+$accent: #253951;
 
 /*
  * Build Variables, don't touch


### PR DESCRIPTION
## Summary
- switch fonts to Montserrat headings and Noto Sans body
- adopt darker blue accent and Doks-style navbar
- add theme-color meta tag

## Testing
- `jekyll build --destination /tmp/site`

------
https://chatgpt.com/codex/tasks/task_e_68a4df7345e88324b9320689725f5134