### PR TITLE
Modernize site styling with Doks-inspired theme

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,8 @@
         {% assign url = site.url | append: site.baseurl | append: page.url %}
     {% endif %}
     <meta name="description" content="{{ desc }}">
-    <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+    <meta name="theme-color" content="#253951">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700|Noto+Sans:400,700&display=swap" rel="stylesheet" type="text/css">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS" href="/feed.xml" />
     <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
     <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
@@ -42,28 +43,28 @@
 <body>
     <div id="particles-js"></div>
     <div class="wrapper">
-        <div class="navbar containernavbar">
-            <a id="author-name" class="alignable pull-left" href="{{ site.url }}{{ site.baseurl }}">{{ site.title }}</a>
-            <ul id="navlist" class="alignable pull-right navbar-ul">
+        <header class="navbar">
+            <div class="container">
+                <a id="author-name" href="{{ site.url }}{{ site.baseurl }}">{{ site.title }}</a>
+                <ul id="navlist" class="navbar-ul">
                 {% for x in site.nav %}
                     {% if x.lang == page.lang %}
                         {% if x.name == "Resume" %}
-                            <li class="alignable pull-left nav-list"><a target="_blank" href="{{ x.link }}">{{ x.name }}</a>
+                            <li class="nav-list"><a target="_blank" href="{{ x.link }}">{{ x.name }}</a>
                         {% else %}
-                            <li class="alignable pull-left nav-list"><a href="{{ x.link }}">{{ x.name }}</a>
+                            <li class="nav-list"><a href="{{ x.link }}">{{ x.name }}</a>
                         {% endif %}
                     {% endif %}
                 {% endfor %}
                 {% if page.lang == "en" %}
-                    <li class="alignable pull-left nav-list"><a class="lang" style="color: black" href="/">FR</a>
+                    <li class="nav-list"><a class="lang" href="/">FR</a>
                 {% else %}
-                    <li class="alignable pull-left nav-list"><a class="lang" style="color: black" href="/en/about">EN</a>
+                    <li class="nav-list"><a class="lang" href="/en/about">EN</a>
                 {% endif %}
                             </li>
-            </ul>
-        </div>
-        <div style="clear:both"></div>
-        <hr>
+                </ul>
+            </div>
+        </header>
         {% if page.is_contact == true %}
             <div class="container content contact">
         {% else %}

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -11,23 +11,29 @@ html {
 }
 body {
     margin: 0;
-    font-family: "Lato";
+    font-family: "Noto Sans", sans-serif;
+    color: $accent;
+    background: #fff;
     height: auto;
-    padding-bottom: 50px;
+    padding: 5.625rem 0 50px 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: "Montserrat", sans-serif;
+    color: $accent;
 }
 
 #particles-js canvas {
-    opacity: 1;
+    opacity: 0.3;
 }
 
 #particles-js {
-    padding-top: 50px;
     width: 100vw;
     height: 100vh;
     position: fixed;
     z-index: -1 !important;
     top: 0;
-    left: 0
+    left: 0;
 }
 
 a {
@@ -53,47 +59,65 @@ hr {
  */
 
 #author-name {
-    font-size: 30px;
-    color: #272727;
-    display: inline-block;
+    font-size: 2rem;
+    font-weight: bold;
+    color: $accent;
+    font-family: "Montserrat", sans-serif;
 }
+
 .navbar {
-    padding: 50px 0 50px 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 5.625rem;
+    background-color: #fff;
+    border-bottom: 1px solid rgba(37,57,81,.15);
+    z-index: 1000;
 }
+
+.navbar .container {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
 .navbar-ul {
-    display: inline-block;
+    list-style: none;
+    display: flex;
+    gap: 2rem;
     margin: 0;
-    padding: 5px 0 5px 0;
-    margin-left: 20px;
+    padding: 0;
 }
+
+.navbar-ul a {
+    color: $accent;
+    font-family: "Montserrat", sans-serif;
+    font-weight: 500;
+    text-transform: uppercase;
+    border-bottom: 2px solid transparent;
+    line-height: 5.625rem;
+    padding: 0;
+}
+
+.navbar-ul a:hover {
+    border-color: $accent;
+    text-decoration: none;
+}
+
 .nav-list {
-    list-style-type: none;
-    margin: 5px 5px 0 10px;
-}
-.alignable {
-    display: inline-block;
-}
-.pull-left {
-    @extend .alignable;
-    float: left;
-}
-.pull-right {
-    @extend .alignable;
-    float: right;
+    margin: 0;
 }
 
 /* Divs */
+
 
 .container {
     max-width: $max-width;
     margin: auto;
 }
-.containernavbar {
-    background-color: #FFFFFF;
-    max-width: $max-width;
-    margin: auto;
-    z-index: 0;
-}
+
 .wrapper {
     min-height: 100%;
 }
@@ -112,39 +136,27 @@ hr {
         max-width: 83%;
     }
     .navbar-ul {
-        margin-top: 5px;
+        gap: 1rem;
     }
 }
 
 @media (max-width: 500px) {
-    body {
-        background-image: none;
-      }
-	.navbar {
-		text-align: center;
-		padding: 50px 0px 100px 0px;
-	}
-	#author-name {
-		width: 100%;
-		float: none;
-	}
-	#navlist {
-		padding: 10px 0 10px 0;
-		margin: 0;
-		display: block;
-		float: none;
-		text-align: center;
-		width: 100%;
-	}
-	#navlist li.alignable {
-		display: inline-block;
-	}
-	#navlist li.pull-left {
-		float: none;
-	}
-	#navlist li.nav-list {
-		margin: 0;
-	}
+    .navbar {
+        height: auto;
+        padding: 1rem 0;
+    }
+    .navbar .container {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .navbar-ul {
+        flex-wrap: wrap;
+        line-height: 1.5;
+    }
+    .navbar-ul a {
+        line-height: 1.5;
+        padding: 0.5rem 0;
+    }
 }
 
 @import "typography";

--- a/_sass/vars.scss
+++ b/_sass/vars.scss
@@ -2,7 +2,7 @@
  * Customization Variables
  */
 
-$accent: #318CE7;
+$accent: #253951;
 
 /*
  * Build Variables, don't touch


### PR DESCRIPTION
## Summary
- switch fonts to Montserrat headings and Noto Sans body
- adopt darker blue accent and Doks-style navbar
- add theme-color meta tag
- implement fixed white navigation bar and responsive layout

## Testing
- `jekyll build --destination /tmp/site`


------
https://chatgpt.com/codex/tasks/task_e_68a4df7345e88324b9320689725f5134