### PR TITLE
Expand header bar and widen content layout

### DIFF
--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -85,6 +85,9 @@ hr {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    width: 100%;
+    max-width: 100%;
+    padding: 0 2rem;
 }
 
 .navbar-ul {
@@ -118,6 +121,7 @@ hr {
 
 
 .container {
+    width: 90%;
     max-width: $max-width;
     margin: auto;
 }
@@ -135,6 +139,7 @@ hr {
 
 @media (max-width: 800px) {
     .container {
+        width: 90%;
         max-width: $med-width;
         transition: 0.3s ease all;
     }
@@ -142,7 +147,7 @@ hr {
 
 @media (max-width: 650px) {
     .container {
-        max-width: 83%;
+        width: 83%;
     }
     .navbar-ul {
         gap: 1rem;

--- a/_sass/vars.scss
+++ b/_sass/vars.scss
@@ -8,6 +8,6 @@ $accent: #253951;
  * Build Variables, don't touch
  */
 
-$max-width: 700px;
+$max-width: 1000px;
 $med-width: 600px;
 $small-width: 480px;


### PR DESCRIPTION
## Summary
- Allow navigation header to span the full viewport
- Broaden content container and update layout variables for better use of screen width

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a75c4723588324b695f8ed460cfd45