### PR TITLE
Simplify terminal shell layout and styling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}" data-theme="light">
 <head>
-    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="keywords" content="blog, accent, {{ site.author }}, {{ site.title }}, jekyll">
     <meta name="author" content="{{ site.author }}">
     <meta name="google-site-verification" content="Xm_5ZOSckkc8NNSBhmoNLbWjGT5-ig0jnhVg4TkJFUA" />
@@ -21,13 +21,16 @@
         {% assign url = site.url | append: site.baseurl | append: page.url %}
     {% endif %}
     <meta name="description" content="{{ desc }}">
-    <meta name="theme-color" content="#253951">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700|Noto+Sans:400,700&display=swap" rel="stylesheet" type="text/css">
-    <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS" href="/feed.xml" />
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
-    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
-    <link rel="shortcut icon" href="/images/favicon/favicon.ico">
+    <meta name="theme-color" content="#0f120a" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#041411" media="(prefers-color-scheme: dark)">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS" href="{{ '/feed.xml' | relative_url }}" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Source+Code+Pro:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ '/css/main.css' | relative_url }}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ '/images/favicon/favicon-32x32.png' | relative_url }}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ '/images/favicon/favicon-16x16.png' | relative_url }}">
+    <link rel="shortcut icon" href="{{ '/images/favicon/favicon.ico' | relative_url }}">
     <!--KaTeX-->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
@@ -41,40 +44,105 @@
     </script>
 </head>
 <body>
-    <div id="particles-js"></div>
-    <div class="wrapper">
-        <header class="navbar">
-            <div class="container">
-                <a id="author-name" href="{{ site.url }}{{ site.baseurl }}">{{ site.title }}</a>
-                <ul id="navlist" class="navbar-ul">
+    <div class="site">
+        {% if page.lang == "en" %}
+            {% assign alt_href = '/' | relative_url %}
+            {% assign alt_label = 'FR' %}
+        {% else %}
+            {% assign alt_href = '/en/about' | relative_url %}
+            {% assign alt_label = 'EN' %}
+        {% endif %}
+        <header class="terminal-header" role="banner">
+            <div class="terminal-header__inner">
+                <div class="brand">
+                    <span class="brand__prompt" aria-hidden="true">&gt;_</span>
+                    <a class="brand__link" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+                </div>
+                <div class="terminal-controls">
+                    <a class="lang-toggle" href="{{ alt_href }}">{{ alt_label }}</a>
+                    <button class="theme-toggle" type="button" data-theme-toggle data-theme-state="light">
+                        <span class="theme-toggle__label sr-only">Toggle theme</span>
+                    </button>
+                </div>
+            </div>
+            {% if site.description %}
+                <p class="terminal-subtitle" data-terminal-line>
+                    <span aria-hidden="true">~$</span>
+                    <span>{{ site.description }}</span>
+                </p>
+            {% endif %}
+            <nav class="terminal-nav" aria-label="Primary">
+                <div class="terminal-path" aria-hidden="true">~/</div>
+                <ul class="terminal-menu">
                 {% for x in site.nav %}
                     {% if x.lang == page.lang %}
-                        {% if x.name == "Resume" %}
-                            <li class="nav-list"><a target="_blank" href="{{ x.link }}">{{ x.name }}</a>
-                        {% else %}
-                            <li class="nav-list"><a href="{{ x.link }}">{{ x.name }}</a>
-                        {% endif %}
+                        <li>
+                            {% if x.name == "Resume" or x.name == "CV" %}
+                                <a target="_blank" rel="noopener" href="{{ x.link }}">{{ x.name }}</a>
+                            {% else %}
+                                <a href="{{ x.link }}">{{ x.name }}</a>
+                            {% endif %}
+                        </li>
                     {% endif %}
                 {% endfor %}
-                {% if page.lang == "en" %}
-                    <li class="nav-list"><a class="lang" href="/">FR</a>
-                {% else %}
-                    <li class="nav-list"><a class="lang" href="/en/about">EN</a>
-                {% endif %}
-                            </li>
                 </ul>
-            </div>
+            </nav>
         </header>
-        {% if page.is_contact == true %}
-            <div class="container content contact">
-        {% else %}
-            <div class="container content">
-        {% endif %}
-                {{ content }}
-            </div>
+        <main class="terminal-main content{% if page.is_contact == true %} contact{% endif %}">
+            {{ content }}
+        </main>
     </div>
-    <script src="/particles.js-master/particles.js"></script>
-    <script src="/particles.js-master/demo/js/app.js"></script>
+    <script>
+        (function () {
+            var storageKey = "preferred-theme";
+            var root = document.documentElement;
+            var toggle = null;
+
+            function applyTheme(theme) {
+                root.setAttribute("data-theme", theme);
+                if (toggle) {
+                    toggle.setAttribute("data-theme-state", theme);
+                }
+            }
+
+            function getPreferredTheme() {
+                var stored = localStorage.getItem(storageKey);
+                if (stored) {
+                    return stored;
+                }
+                return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+            }
+
+            function setupToggle() {
+                toggle = document.querySelector("[data-theme-toggle]");
+                if (!toggle) {
+                    return;
+                }
+                toggle.addEventListener("click", function () {
+                    var nextTheme = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
+                    applyTheme(nextTheme);
+                    localStorage.setItem(storageKey, nextTheme);
+                });
+                toggle.setAttribute("data-theme-state", root.getAttribute("data-theme"));
+            }
+
+            var initial = getPreferredTheme();
+            applyTheme(initial);
+            setupToggle();
+
+            if (toggle) {
+                toggle.setAttribute("data-theme-state", root.getAttribute("data-theme"));
+            }
+
+            if (window.matchMedia) {
+                var mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+                mediaQuery.addEventListener("change", function (event) {
+                    if (!localStorage.getItem(storageKey)) {
+                        applyTheme(event.matches ? "dark" : "light");
+                    }
+                });
+            }
+        })();
+    </script>
 </body>
-<footer>
-</footer>
+</html>

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -1,177 +1,587 @@
 @import "vars";
 
-/*
- * Basic
- */
-
-html {
-    height: 100%;
-    margin: 0;
-    padding: 0;
+:root {
+    --font-family: "IBM Plex Mono", "Source Code Pro", monospace;
+    --background-color: #0f120a;
+    --background-shine: rgba(255, 240, 206, 0.08);
+    --surface-color: #11160d;
+    --surface-edge: #1b2313;
+    --surface-border: rgba(255, 226, 175, 0.08);
+    --text-color: #f5f2d2;
+    --muted-color: rgba(245, 242, 210, 0.64);
+    --accent-color: #ffd166;
+    --accent-glow: rgba(255, 209, 102, 0.35);
+    --divider-color: rgba(245, 242, 210, 0.15);
+    --nav-pill: rgba(255, 209, 102, 0.12);
+    --nav-pill-border: rgba(255, 209, 102, 0.32);
+    --screen-mask: rgba(12, 18, 8, 0.55);
+    --shadow-color: rgba(0, 0, 0, 0.55);
+    --focus-outline: rgba(255, 209, 102, 0.45);
+    --selection-bg: rgba(255, 209, 102, 0.35);
+    --selection-text: #13140f;
 }
+
+html[data-theme='dark'] {
+    --background-color: #03080a;
+    --background-shine: rgba(134, 255, 205, 0.08);
+    --surface-color: #041411;
+    --surface-edge: #08231b;
+    --surface-border: rgba(127, 255, 212, 0.12);
+    --text-color: #cbffe4;
+    --muted-color: rgba(203, 255, 228, 0.62);
+    --accent-color: #7fffd4;
+    --accent-glow: rgba(127, 255, 212, 0.42);
+    --divider-color: rgba(127, 255, 212, 0.18);
+    --nav-pill: rgba(127, 255, 212, 0.12);
+    --nav-pill-border: rgba(127, 255, 212, 0.36);
+    --screen-mask: rgba(2, 23, 18, 0.58);
+    --shadow-color: rgba(0, 0, 0, 0.66);
+    --focus-outline: rgba(127, 255, 212, 0.42);
+    --selection-bg: rgba(127, 255, 212, 0.3);
+    --selection-text: #041411;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html,
 body {
     margin: 0;
-    font-family: "Noto Sans", sans-serif;
-    color: $accent;
-    background: #fff;
-    height: auto;
-    padding: 5.625rem 0 50px 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    font-family: "Montserrat", sans-serif;
-    color: $accent;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    font-family: "Montserrat", sans-serif;
-}
-
-#particles-js canvas {
-    opacity: 0.3;
-}
-
-#particles-js {
-    width: 100vw;
-    height: 100vh;
-    position: fixed;
-    z-index: -1 !important;
-    top: 0;
-    left: 0;
-}
-
-a {
-    text-decoration: none;
-    color: $accent;
-}
-a:hover {
-    text-decoration: underline;
-}
-a.lang:hover{
-    text-decoration: none;
-    font-weight:bold;
-}
-hr {
-    border: 0;
-    height: 0;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-}
-
-/*
- * Navbar
- */
-
-#author-name {
-    font-size: 2rem;
-    font-weight: bold;
-    color: $accent;
-    font-family: "Montserrat", sans-serif;
-}
-
-.navbar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 5.625rem;
-    background-color: #fff;
-    border-bottom: 1px solid rgba(37,57,81,.15);
-    z-index: 1000;
-}
-
-.navbar .container {
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    max-width: 100%;
-    padding: 0 2rem;
-}
-
-.navbar-ul {
-    list-style: none;
-    display: flex;
-    gap: 2rem;
-    margin: 0;
     padding: 0;
-}
-
-.navbar-ul a {
-    color: $accent;
-    font-family: "Montserrat", sans-serif;
-    font-weight: 500;
-    text-transform: uppercase;
-    border-bottom: 2px solid transparent;
-    line-height: 5.625rem;
-    padding: 0;
-}
-
-.navbar-ul a:hover {
-    border-color: $accent;
-    text-decoration: none;
-}
-
-.nav-list {
-    margin: 0;
-}
-
-/* Divs */
-
-
-.container {
-    width: 90%;
-    max-width: $max-width;
-    margin: auto;
-}
-.containernavbar {
-    background-color: $accent;
-    width: 100%;
-    margin: 0;
-    z-index: 0;
-}
-.wrapper {
     min-height: 100%;
 }
 
-/* Mobile */
-
-@media (max-width: 800px) {
-    .container {
-        width: 90%;
-        max-width: $med-width;
-        transition: 0.3s ease all;
-    }
+body {
+    position: relative;
+    background: var(--background-color);
+    color: var(--text-color);
+    font-family: var(--font-family);
+    font-size: clamp(13px, 1.05vw, 16px);
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
 
-@media (max-width: 650px) {
-    .container {
-        width: 83%;
-    }
-    .navbar-ul {
-        gap: 1rem;
-    }
+::selection {
+    background: var(--selection-bg);
+    color: var(--selection-text);
 }
 
-@media (max-width: 500px) {
-    .navbar {
-        height: auto;
-        padding: 1rem 0;
+a {
+    color: inherit;
+    text-decoration: none;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    transition: color 0.18s ease, text-shadow 0.18s ease;
+}
+
+a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -2px;
+    width: 100%;
+    height: 1px;
+    background: currentColor;
+    transform-origin: left;
+    transform: scaleX(0.35);
+    opacity: 0.55;
+    transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+a:hover,
+a:focus-visible {
+    color: var(--accent-color);
+    text-shadow: 0 0 18px var(--accent-glow);
+}
+
+a:hover::after,
+a:focus-visible::after {
+    transform: scaleX(1);
+    opacity: 0.85;
+}
+
+p,
+ul,
+ol {
+    margin: 0;
+}
+
+.site {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.75rem, 4vw, 3rem);
+    padding: clamp(2.5rem, 6vw, 4rem) clamp(3vw, 6vw, 4.5rem) clamp(4rem, 8vw, 5.5rem);
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.terminal-header {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 2vw, 1.6rem);
+}
+
+.terminal-header__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: clamp(1rem, 3vw, 2.5rem);
+}
+
+.terminal-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.lang-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    border: 1px dashed var(--divider-color);
+    font-size: 0.7rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.lang-toggle:hover,
+.lang-toggle:focus-visible {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: clamp(1rem, 2.4vw, 1.25rem);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.brand__prompt {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2rem 0.45rem;
+    border-left: 2px solid var(--accent-color);
+    color: var(--accent-color);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    text-shadow: 0 0 12px var(--accent-glow);
+    animation: prompt-flicker 2.8s steps(2, end) infinite;
+}
+
+.brand__link {
+    position: relative;
+    padding: 0.15rem 0;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    transition: color 0.18s ease;
+}
+
+.brand__link::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -0.25rem;
+    width: 100%;
+    height: 2px;
+    background: currentColor;
+    transform-origin: left;
+    transform: scaleX(0.35);
+    opacity: 0.4;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.brand__link:hover,
+.brand__link:focus-visible {
+    color: var(--accent-color);
+}
+
+.brand__link:hover::after,
+.brand__link:focus-visible::after {
+    transform: scaleX(1);
+    opacity: 0.85;
+}
+
+.theme-toggle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    border: 1px dashed var(--divider-color);
+    background: transparent;
+    color: inherit;
+    font-family: var(--font-family);
+    font-size: 0.7rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.04);
+    outline: none;
+}
+
+.theme-toggle::after {
+    content: attr(data-theme-state);
+}
+
+.theme-toggle[data-theme-state='dark'] {
+    border-style: solid;
+}
+
+.theme-toggle__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.terminal-subtitle {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0;
+    color: var(--muted-color);
+    letter-spacing: 0.05em;
+}
+
+.terminal-subtitle > span:first-child {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.3rem;
+    color: var(--accent-color);
+    font-weight: 600;
+    animation: caret-blink 2.8s steps(2, end) infinite;
+}
+
+.terminal-nav {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.65rem 1rem;
+    margin: 0;
+    padding: 0 0 clamp(1rem, 4vw, 1.4rem);
+    border-bottom: 1px dashed var(--divider-color);
+}
+
+.terminal-path {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    color: var(--muted-color);
+    text-transform: uppercase;
+}
+
+.terminal-path::before {
+    content: "//";
+    color: var(--accent-color);
+    letter-spacing: 0.18em;
+}
+
+.terminal-menu {
+    list-style: none;
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.65rem 0.9rem;
+    margin: 0;
+    padding: 0;
+}
+
+.terminal-menu li {
+    display: inline-flex;
+    align-items: center;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.82rem;
+    color: var(--muted-color);
+}
+
+.terminal-menu li::after {
+    content: "/";
+    margin-left: 0.6rem;
+    color: var(--divider-color);
+}
+
+.terminal-menu li:last-child::after {
+    display: none;
+}
+
+.terminal-menu a {
+    padding: 0.15rem 0;
+    transition: color 0.2s ease;
+}
+
+.terminal-menu a:hover,
+.terminal-menu a:focus-visible {
+    color: var(--accent-color);
+}
+
+.terminal-main {
+    position: relative;
+    padding-top: clamp(1.5rem, 5vw, 2.4rem);
+    border-left: 2px solid var(--divider-color);
+    padding-left: clamp(1.2rem, 5vw, 2.3rem);
+    animation: panel-rise 0.6s ease-out both;
+}
+
+.content {
+    margin: 0;
+}
+
+.content > *:first-child {
+    margin-top: 0;
+}
+
+.content > * + * {
+    margin-top: 1.35rem;
+}
+
+.content hr {
+    border: none;
+    margin: 2.25rem 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--divider-color), transparent);
+}
+
+.content blockquote {
+    margin: 1.8rem 0;
+    padding: 0.65rem 1.5rem;
+    border-left: 3px solid var(--accent-color);
+    background: transparent;
+    color: var(--muted-color);
+    font-style: italic;
+}
+
+.content code {
+    font-family: var(--font-family);
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--accent-color);
+    padding: 0.15rem 0.4rem;
+    border-radius: 0.35rem;
+}
+
+pre {
+    margin: 1.75rem 0;
+    padding: 1.15rem 1.4rem;
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.28);
+    border: 1px dashed var(--divider-color);
+    overflow-x: auto;
+    font-family: var(--font-family);
+    font-size: 0.95em;
+    line-height: 1.6;
+}
+
+pre code {
+    background: none;
+    padding: 0;
+    color: inherit;
+}
+
+input,
+select,
+textarea,
+button {
+    font-family: var(--font-family);
+    font-size: 0.95em;
+    color: inherit;
+}
+
+input,
+select,
+textarea {
+    width: 100%;
+    padding: 0.55rem 0.5rem;
+    border: 1px dashed var(--divider-color);
+    border-radius: 0.5rem;
+    background: rgba(0, 0, 0, 0.2);
+    caret-color: var(--accent-color);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px var(--focus-outline);
+    outline: none;
+}
+
+textarea {
+    resize: vertical;
+    min-height: 160px;
+}
+
+button,
+input[type="submit"] {
+    cursor: pointer;
+    padding: 0.55rem 1.4rem;
+    border-radius: 999px;
+    border: 1px dashed var(--divider-color);
+    background: transparent;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    transition: border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover,
+button:focus-visible,
+input[type="submit"]:hover,
+input[type="submit"]:focus-visible {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+    box-shadow: 0 0 0 3px var(--focus-outline);
+    outline: none;
+}
+
+::placeholder {
+    color: var(--muted-color);
+    opacity: 0.8;
+}
+
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.14);
+    border-radius: 999px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 760px) {
+    .site {
+        padding-top: clamp(1.5rem, 8vw, 2.25rem);
     }
-    .navbar .container {
+
+    .terminal-header__inner {
         flex-direction: column;
         align-items: flex-start;
     }
-    .navbar-ul {
-        flex-wrap: wrap;
-        line-height: 1.5;
+
+    .terminal-controls {
+        width: 100%;
+        justify-content: flex-start;
+        gap: 0.5rem;
     }
-    .navbar-ul a {
-        line-height: 1.5;
-        padding: 0.5rem 0;
+
+    .theme-toggle {
+        align-self: flex-start;
+    }
+
+    .terminal-nav {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .terminal-path::before {
+        display: none;
     }
 }
 
-@import "typography";
-@import "tables";
+@media (max-width: 520px) {
+    .terminal-menu {
+        gap: 0.5rem 0.65rem;
+    }
+
+    .terminal-main {
+        border-left: none;
+        padding-left: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+@keyframes prompt-flicker {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    45% {
+        opacity: 0.75;
+    }
+    50% {
+        opacity: 0.3;
+    }
+    55% {
+        opacity: 1;
+    }
+}
+
+@keyframes caret-blink {
+    0%,
+    49% {
+        opacity: 1;
+    }
+    50%,
+    100% {
+        opacity: 0.25;
+    }
+}
+
+@keyframes panel-rise {
+    from {
+        opacity: 0;
+        transform: translateY(14px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/_sass/tables.scss
+++ b/_sass/tables.scss
@@ -1,34 +1,40 @@
 table {
-    margin: 15px 0;
-    border-collapse: collapse;
     width: 100%;
-    padding: 0;
+    border-collapse: collapse;
+    margin: 2rem 0;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.85rem;
+    overflow: hidden;
+    box-shadow: 0 18px 32px -26px var(--shadow-color);
 }
-table tr {
-    border-top: 1px solid #cccccc00;
-    background-color:#cccccc00;
-    margin: 0;
-    padding: 0;
+
+table thead {
+    background: rgba(255, 255, 255, 0.05);
 }
-table tr:nth-child(2n) {
-    background-color: #cccccc00;
+
+table th,
+table td {
+    padding: 0.75rem 0.95rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
-table tr th {
-    font-weight: bold;
-    border: 0px solid #cccccc00;
-    text-align: center;
-    margin: 0;
-    padding: 6px 13px;
+
+table th {
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-color);
 }
-table tr td {
-    border: 0px solid #cccccc00;
-    text-align: center;
-    margin: 0;
-    padding: 6px 13px;
+
+table tbody tr:nth-child(even) {
+    background: rgba(255, 255, 255, 0.03);
 }
-table tr th :first-child, table tr td :first-child {
-    margin: 0;
+
+table tbody tr:hover {
+    background: rgba(255, 255, 255, 0.06);
 }
-table tr th :last-child, table tr td :last-child {
-    margin: 0;
+
+table tr:last-child td {
+    border-bottom: none;
 }

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -1,30 +1,128 @@
 @import "vars";
 
 .content {
-    a:hover {
-        text-decoration: underline;
+    h1,
+    h2,
+    h3,
+    h4 {
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        margin: 2.4rem 0 1.25rem;
+        color: var(--text-color);
     }
-    ul > li {
-        margin: 5px 0 5px 0;
+
+    h1 {
+        font-size: clamp(1.9rem, 5vw, 2.5rem);
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        padding-bottom: 0.75rem;
+        position: relative;
     }
+
+    h1::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        width: 84px;
+        height: 3px;
+        background: linear-gradient(90deg, var(--accent-color), transparent);
+    }
+
+    h2 {
+        font-size: clamp(1.5rem, 4.5vw, 2rem);
+        padding-left: 1.1rem;
+        border-left: 4px solid var(--accent-color);
+        text-transform: none;
+    }
+
+    h3 {
+        font-size: clamp(1.25rem, 3.5vw, 1.6rem);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted-color);
+    }
+
+    h4 {
+        font-size: clamp(1.05rem, 3vw, 1.25rem);
+        text-transform: uppercase;
+        color: var(--muted-color);
+        letter-spacing: 0.14em;
+    }
+
+    p {
+        margin: 0 0 1.1rem;
+    }
+
+    strong {
+        color: var(--accent-color);
+    }
+
+    em {
+        color: var(--muted-color);
+    }
+
     ul {
-        padding: 0 20px 0 20px;;
+        list-style: none;
+        padding-left: 0;
+        margin: 0 0 1.5rem 0;
     }
+
+    ul > li {
+        position: relative;
+        padding-left: 1.6rem;
+        margin: 0.5rem 0;
+    }
+
+    ul > li::before {
+        content: "▸";
+        position: absolute;
+        left: 0;
+        top: 0.05rem;
+        color: var(--accent-color);
+    }
+
     ol {
-        padding: 0 0 0 30px;
+        margin: 0 0 1.5rem 1.6rem;
+        padding-left: 0;
     }
-    ol > li:before {
-        left: -30px;
-        font-weight:bold;
+
+    ol > li {
+        margin: 0.5rem 0;
     }
-    ol li::marker {
-        font-weight: bold;
+
+    li > ul,
+    li > ol {
+        margin-top: 0.5rem;
     }
+
     blockquote {
-        //border: 1px solid black;
-        border-left: 5px solid #333333;
-        margin: 20px 0 20px 0;
-        padding: 2px 8px 2px 8px;
+        border-left: 4px solid var(--accent-color);
+        padding: 0.85rem 1.75rem;
+        margin: 2rem 0;
+        background: rgba(0, 0, 0, 0.35);
+        color: var(--muted-color);
         font-style: italic;
+    }
+
+    img,
+    video,
+    iframe {
+        max-width: 100%;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 18px 36px -24px var(--shadow-color);
+    }
+
+    figure {
+        margin: 2.1rem 0;
+        text-align: center;
+    }
+
+    figcaption {
+        margin-top: 0.75rem;
+        font-size: 0.85rem;
+        color: var(--muted-color);
+        letter-spacing: 0.08em;
     }
 }


### PR DESCRIPTION
## Summary
- streamline the default layout into a minimal console header with inline language/theme controls and open content surface
- refactor the console styling to drop the window chrome, keep slash navigation, and introduce dashed borders and subtle caret animations for a cleaner terminal feel
- refresh typography, code, and form treatments to match the simplified aesthetic while preserving bilingual and math capabilities

## Testing
- `bundle exec jekyll build` *(fails: missing Gemfile in repository)*
- `jekyll build` *(fails: jekyll command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d692b61e308324bd0701472617af6f