### PR TITLE
Brighten light theme and square math callouts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}" data-theme="light">
 <head>
-    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="keywords" content="blog, accent, {{ site.author }}, {{ site.title }}, jekyll">
     <meta name="author" content="{{ site.author }}">
     <meta name="google-site-verification" content="Xm_5ZOSckkc8NNSBhmoNLbWjGT5-ig0jnhVg4TkJFUA" />
@@ -21,13 +21,16 @@
         {% assign url = site.url | append: site.baseurl | append: page.url %}
     {% endif %}
     <meta name="description" content="{{ desc }}">
-    <meta name="theme-color" content="#253951">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700|Noto+Sans:400,700&display=swap" rel="stylesheet" type="text/css">
-    <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS" href="/feed.xml" />
-    <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
-    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
-    <link rel="shortcut icon" href="/images/favicon/favicon.ico">
+    <meta name="theme-color" content="#0f120a" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#041411" media="(prefers-color-scheme: dark)">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS" href="{{ '/feed.xml' | relative_url }}" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Source+Code+Pro:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ '/css/main.css' | relative_url }}">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ '/images/favicon/favicon-32x32.png' | relative_url }}">
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ '/images/favicon/favicon-16x16.png' | relative_url }}">
+    <link rel="shortcut icon" href="{{ '/images/favicon/favicon.ico' | relative_url }}">
     <!--KaTeX-->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
@@ -41,40 +44,105 @@
     </script>
 </head>
 <body>
-    <div id="particles-js"></div>
-    <div class="wrapper">
-        <header class="navbar">
-            <div class="container">
-                <a id="author-name" href="{{ site.url }}{{ site.baseurl }}">{{ site.title }}</a>
-                <ul id="navlist" class="navbar-ul">
+    <div class="site">
+        {% if page.lang == "en" %}
+            {% assign alt_href = '/' | relative_url %}
+            {% assign alt_label = 'FR' %}
+        {% else %}
+            {% assign alt_href = '/en/about' | relative_url %}
+            {% assign alt_label = 'EN' %}
+        {% endif %}
+        <header class="terminal-header" role="banner">
+            <div class="terminal-header__inner">
+                <div class="brand">
+                    <span class="brand__prompt" aria-hidden="true">&gt;_</span>
+                    <a class="brand__link" href="{{ '/' | relative_url }}">{{ site.title }}</a>
+                </div>
+                <div class="terminal-controls">
+                    <a class="lang-toggle" href="{{ alt_href }}">{{ alt_label }}</a>
+                    <button class="theme-toggle" type="button" data-theme-toggle data-theme-state="light">
+                        <span class="theme-toggle__label sr-only">Toggle theme</span>
+                    </button>
+                </div>
+            </div>
+            {% if site.description %}
+                <p class="terminal-subtitle" data-terminal-line>
+                    <span aria-hidden="true">~$</span>
+                    <span>{{ site.description }}</span>
+                </p>
+            {% endif %}
+            <nav class="terminal-nav" aria-label="Primary">
+                <div class="terminal-path" aria-hidden="true">~/</div>
+                <ul class="terminal-menu">
                 {% for x in site.nav %}
                     {% if x.lang == page.lang %}
-                        {% if x.name == "Resume" %}
-                            <li class="nav-list"><a target="_blank" href="{{ x.link }}">{{ x.name }}</a>
-                        {% else %}
-                            <li class="nav-list"><a href="{{ x.link }}">{{ x.name }}</a>
-                        {% endif %}
+                        <li>
+                            {% if x.name == "Resume" or x.name == "CV" %}
+                                <a target="_blank" rel="noopener" href="{{ x.link }}">{{ x.name }}</a>
+                            {% else %}
+                                <a href="{{ x.link }}">{{ x.name }}</a>
+                            {% endif %}
+                        </li>
                     {% endif %}
                 {% endfor %}
-                {% if page.lang == "en" %}
-                    <li class="nav-list"><a class="lang" href="/">FR</a>
-                {% else %}
-                    <li class="nav-list"><a class="lang" href="/en/about">EN</a>
-                {% endif %}
-                            </li>
                 </ul>
-            </div>
+            </nav>
         </header>
-        {% if page.is_contact == true %}
-            <div class="container content contact">
-        {% else %}
-            <div class="container content">
-        {% endif %}
-                {{ content }}
-            </div>
+        <main class="terminal-main content{% if page.is_contact == true %} contact{% endif %}">
+            {{ content }}
+        </main>
     </div>
-    <script src="/particles.js-master/particles.js"></script>
-    <script src="/particles.js-master/demo/js/app.js"></script>
+    <script>
+        (function () {
+            var storageKey = "preferred-theme";
+            var root = document.documentElement;
+            var toggle = null;
+
+            function applyTheme(theme) {
+                root.setAttribute("data-theme", theme);
+                if (toggle) {
+                    toggle.setAttribute("data-theme-state", theme);
+                }
+            }
+
+            function getPreferredTheme() {
+                var stored = localStorage.getItem(storageKey);
+                if (stored) {
+                    return stored;
+                }
+                return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+            }
+
+            function setupToggle() {
+                toggle = document.querySelector("[data-theme-toggle]");
+                if (!toggle) {
+                    return;
+                }
+                toggle.addEventListener("click", function () {
+                    var nextTheme = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
+                    applyTheme(nextTheme);
+                    localStorage.setItem(storageKey, nextTheme);
+                });
+                toggle.setAttribute("data-theme-state", root.getAttribute("data-theme"));
+            }
+
+            var initial = getPreferredTheme();
+            applyTheme(initial);
+            setupToggle();
+
+            if (toggle) {
+                toggle.setAttribute("data-theme-state", root.getAttribute("data-theme"));
+            }
+
+            if (window.matchMedia) {
+                var mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+                mediaQuery.addEventListener("change", function (event) {
+                    if (!localStorage.getItem(storageKey)) {
+                        applyTheme(event.matches ? "dark" : "light");
+                    }
+                });
+            }
+        })();
+    </script>
 </body>
-<footer>
-</footer>
+</html>

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -1,177 +1,586 @@
 @import "vars";
 
-/*
- * Basic
- */
-
-html {
-    height: 100%;
-    margin: 0;
-    padding: 0;
+:root {
+    --font-family: "IBM Plex Mono", "Source Code Pro", monospace;
+    --background-color: #fdf6e3;
+    --background-shine: rgba(147, 161, 161, 0.12);
+    --surface-color: #f7efda;
+    --surface-edge: #e1d9b8;
+    --surface-border: rgba(101, 123, 131, 0.22);
+    --text-color: #586e75;
+    --muted-color: rgba(88, 110, 117, 0.7);
+    --accent-color: #b58900;
+    --accent-glow: rgba(181, 137, 0, 0.32);
+    --divider-color: rgba(101, 123, 131, 0.25);
+    --nav-pill: rgba(181, 137, 0, 0.12);
+    --nav-pill-border: rgba(181, 137, 0, 0.32);
+    --screen-mask: rgba(253, 246, 227, 0.55);
+    --shadow-color: rgba(51, 61, 66, 0.18);
+    --focus-outline: rgba(38, 139, 210, 0.45);
+    --selection-bg: rgba(38, 139, 210, 0.25);
+    --selection-text: #002b36;
 }
+
+html[data-theme='dark'] {
+    --background-color: #03080a;
+    --background-shine: rgba(134, 255, 205, 0.08);
+    --surface-color: #041411;
+    --surface-edge: #08231b;
+    --surface-border: rgba(127, 255, 212, 0.12);
+    --text-color: #cbffe4;
+    --muted-color: rgba(203, 255, 228, 0.62);
+    --accent-color: #7fffd4;
+    --accent-glow: rgba(127, 255, 212, 0.42);
+    --divider-color: rgba(127, 255, 212, 0.18);
+    --nav-pill: rgba(127, 255, 212, 0.12);
+    --nav-pill-border: rgba(127, 255, 212, 0.36);
+    --screen-mask: rgba(2, 23, 18, 0.58);
+    --shadow-color: rgba(0, 0, 0, 0.66);
+    --focus-outline: rgba(127, 255, 212, 0.42);
+    --selection-bg: rgba(127, 255, 212, 0.3);
+    --selection-text: #041411;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html,
 body {
     margin: 0;
-    font-family: "Noto Sans", sans-serif;
-    color: $accent;
-    background: #fff;
-    height: auto;
-    padding: 5.625rem 0 50px 0;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    font-family: "Montserrat", sans-serif;
-    color: $accent;
-}
-
-h1, h2, h3, h4, h5, h6 {
-    font-family: "Montserrat", sans-serif;
-}
-
-#particles-js canvas {
-    opacity: 0.3;
-}
-
-#particles-js {
-    width: 100vw;
-    height: 100vh;
-    position: fixed;
-    z-index: -1 !important;
-    top: 0;
-    left: 0;
-}
-
-a {
-    text-decoration: none;
-    color: $accent;
-}
-a:hover {
-    text-decoration: underline;
-}
-a.lang:hover{
-    text-decoration: none;
-    font-weight:bold;
-}
-hr {
-    border: 0;
-    height: 0;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-}
-
-/*
- * Navbar
- */
-
-#author-name {
-    font-size: 2rem;
-    font-weight: bold;
-    color: $accent;
-    font-family: "Montserrat", sans-serif;
-}
-
-.navbar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 5.625rem;
-    background-color: #fff;
-    border-bottom: 1px solid rgba(37,57,81,.15);
-    z-index: 1000;
-}
-
-.navbar .container {
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    max-width: 100%;
-    padding: 0 2rem;
-}
-
-.navbar-ul {
-    list-style: none;
-    display: flex;
-    gap: 2rem;
-    margin: 0;
     padding: 0;
-}
-
-.navbar-ul a {
-    color: $accent;
-    font-family: "Montserrat", sans-serif;
-    font-weight: 500;
-    text-transform: uppercase;
-    border-bottom: 2px solid transparent;
-    line-height: 5.625rem;
-    padding: 0;
-}
-
-.navbar-ul a:hover {
-    border-color: $accent;
-    text-decoration: none;
-}
-
-.nav-list {
-    margin: 0;
-}
-
-/* Divs */
-
-
-.container {
-    width: 90%;
-    max-width: $max-width;
-    margin: auto;
-}
-.containernavbar {
-    background-color: $accent;
-    width: 100%;
-    margin: 0;
-    z-index: 0;
-}
-.wrapper {
     min-height: 100%;
 }
 
-/* Mobile */
-
-@media (max-width: 800px) {
-    .container {
-        width: 90%;
-        max-width: $med-width;
-        transition: 0.3s ease all;
-    }
+body {
+    position: relative;
+    background: var(--background-color);
+    color: var(--text-color);
+    font-family: var(--font-family);
+    font-size: clamp(13px, 1.05vw, 16px);
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
 
-@media (max-width: 650px) {
-    .container {
-        width: 83%;
-    }
-    .navbar-ul {
-        gap: 1rem;
-    }
+::selection {
+    background: var(--selection-bg);
+    color: var(--selection-text);
 }
 
-@media (max-width: 500px) {
-    .navbar {
-        height: auto;
-        padding: 1rem 0;
+a {
+    color: inherit;
+    text-decoration: none;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    transition: color 0.18s ease, text-shadow 0.18s ease;
+}
+
+a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -2px;
+    width: 100%;
+    height: 1px;
+    background: currentColor;
+    transform-origin: left;
+    transform: scaleX(0.35);
+    opacity: 0.55;
+    transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+a:hover,
+a:focus-visible {
+    color: var(--accent-color);
+    text-shadow: 0 0 18px var(--accent-glow);
+}
+
+a:hover::after,
+a:focus-visible::after {
+    transform: scaleX(1);
+    opacity: 0.85;
+}
+
+p,
+ul,
+ol {
+    margin: 0;
+}
+
+.site {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1.75rem, 4vw, 3rem);
+    padding: clamp(2.5rem, 6vw, 4rem) clamp(3vw, 6vw, 4.5rem) clamp(4rem, 8vw, 5.5rem);
+    max-width: 960px;
+    margin: 0 auto;
+}
+
+.terminal-header {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(1rem, 2vw, 1.6rem);
+}
+
+.terminal-header__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: clamp(1rem, 3vw, 2.5rem);
+}
+
+.terminal-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.lang-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    border: 1px dashed var(--divider-color);
+    font-size: 0.7rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.lang-toggle:hover,
+.lang-toggle:focus-visible {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: clamp(1rem, 2.4vw, 1.25rem);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.brand__prompt {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2rem 0.45rem;
+    color: var(--accent-color);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    text-shadow: 0 0 12px var(--accent-glow);
+    animation: prompt-flicker 2.8s steps(2, end) infinite;
+}
+
+.brand__link {
+    position: relative;
+    padding: 0.15rem 0;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    transition: color 0.18s ease;
+}
+
+.brand__link::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -0.25rem;
+    width: 100%;
+    height: 2px;
+    background: currentColor;
+    transform-origin: left;
+    transform: scaleX(0.35);
+    opacity: 0.4;
+    transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.brand__link:hover,
+.brand__link:focus-visible {
+    color: var(--accent-color);
+}
+
+.brand__link:hover::after,
+.brand__link:focus-visible::after {
+    transform: scaleX(1);
+    opacity: 0.85;
+}
+
+.theme-toggle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    border: 1px dashed var(--divider-color);
+    background: transparent;
+    color: inherit;
+    font-family: var(--font-family);
+    font-size: 0.7rem;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.04);
+    outline: none;
+}
+
+.theme-toggle::after {
+    content: attr(data-theme-state);
+}
+
+.theme-toggle[data-theme-state='dark'] {
+    border-style: solid;
+}
+
+.theme-toggle__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.terminal-subtitle {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0;
+    color: var(--muted-color);
+    letter-spacing: 0.05em;
+}
+
+.terminal-subtitle > span:first-child {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.3rem;
+    color: var(--accent-color);
+    font-weight: 600;
+    animation: caret-blink 2.8s steps(2, end) infinite;
+}
+
+.terminal-nav {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.65rem 1rem;
+    margin: 0;
+    padding: 0 0 clamp(1rem, 4vw, 1.4rem);
+    border-bottom: 1px dashed var(--divider-color);
+}
+
+.terminal-path {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    color: var(--muted-color);
+    text-transform: uppercase;
+}
+
+.terminal-path::before {
+    content: "//";
+    color: var(--accent-color);
+    letter-spacing: 0.18em;
+}
+
+.terminal-menu {
+    list-style: none;
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.65rem 0.9rem;
+    margin: 0;
+    padding: 0;
+}
+
+.terminal-menu li {
+    display: inline-flex;
+    align-items: center;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.82rem;
+    color: var(--muted-color);
+}
+
+.terminal-menu li::after {
+    content: "/";
+    margin-left: 0.6rem;
+    color: var(--divider-color);
+}
+
+.terminal-menu li:last-child::after {
+    display: none;
+}
+
+.terminal-menu a {
+    padding: 0.15rem 0;
+    transition: color 0.2s ease;
+}
+
+.terminal-menu a:hover,
+.terminal-menu a:focus-visible {
+    color: var(--accent-color);
+}
+
+.terminal-main {
+    position: relative;
+    padding-top: clamp(1.5rem, 5vw, 2.4rem);
+    border-left: 2px solid var(--divider-color);
+    padding-left: clamp(1.2rem, 5vw, 2.3rem);
+    animation: panel-rise 0.6s ease-out both;
+}
+
+.content {
+    margin: 0;
+}
+
+.content > *:first-child {
+    margin-top: 0;
+}
+
+.content > * + * {
+    margin-top: 1.35rem;
+}
+
+.content hr {
+    border: none;
+    margin: 2.25rem 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, var(--divider-color), transparent);
+}
+
+.content blockquote {
+    margin: 1.8rem 0;
+    padding: 0.65rem 1.5rem;
+    border-left: 3px solid var(--accent-color);
+    background: transparent;
+    color: var(--muted-color);
+    font-style: italic;
+}
+
+.content code {
+    font-family: var(--font-family);
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--accent-color);
+    padding: 0.15rem 0.4rem;
+    border-radius: 0.35rem;
+}
+
+pre {
+    margin: 1.75rem 0;
+    padding: 1.15rem 1.4rem;
+    border-radius: 10px;
+    background: rgba(0, 0, 0, 0.28);
+    border: 1px dashed var(--divider-color);
+    overflow-x: auto;
+    font-family: var(--font-family);
+    font-size: 0.95em;
+    line-height: 1.6;
+}
+
+pre code {
+    background: none;
+    padding: 0;
+    color: inherit;
+}
+
+input,
+select,
+textarea,
+button {
+    font-family: var(--font-family);
+    font-size: 0.95em;
+    color: inherit;
+}
+
+input,
+select,
+textarea {
+    width: 100%;
+    padding: 0.55rem 0.5rem;
+    border: 1px dashed var(--divider-color);
+    border-radius: 0.5rem;
+    background: rgba(0, 0, 0, 0.2);
+    caret-color: var(--accent-color);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px var(--focus-outline);
+    outline: none;
+}
+
+textarea {
+    resize: vertical;
+    min-height: 160px;
+}
+
+button,
+input[type="submit"] {
+    cursor: pointer;
+    padding: 0.55rem 1.4rem;
+    border-radius: 999px;
+    border: 1px dashed var(--divider-color);
+    background: transparent;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    transition: border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover,
+button:focus-visible,
+input[type="submit"]:hover,
+input[type="submit"]:focus-visible {
+    border-color: var(--accent-color);
+    color: var(--accent-color);
+    box-shadow: 0 0 0 3px var(--focus-outline);
+    outline: none;
+}
+
+::placeholder {
+    color: var(--muted-color);
+    opacity: 0.8;
+}
+
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.14);
+    border-radius: 999px;
+}
+
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 760px) {
+    .site {
+        padding-top: clamp(1.5rem, 8vw, 2.25rem);
     }
-    .navbar .container {
+
+    .terminal-header__inner {
         flex-direction: column;
         align-items: flex-start;
     }
-    .navbar-ul {
-        flex-wrap: wrap;
-        line-height: 1.5;
+
+    .terminal-controls {
+        width: 100%;
+        justify-content: flex-start;
+        gap: 0.5rem;
     }
-    .navbar-ul a {
-        line-height: 1.5;
-        padding: 0.5rem 0;
+
+    .theme-toggle {
+        align-self: flex-start;
+    }
+
+    .terminal-nav {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .terminal-path::before {
+        display: none;
     }
 }
 
-@import "typography";
-@import "tables";
+@media (max-width: 520px) {
+    .terminal-menu {
+        gap: 0.5rem 0.65rem;
+    }
+
+    .terminal-main {
+        border-left: none;
+        padding-left: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+@keyframes prompt-flicker {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    45% {
+        opacity: 0.75;
+    }
+    50% {
+        opacity: 0.3;
+    }
+    55% {
+        opacity: 1;
+    }
+}
+
+@keyframes caret-blink {
+    0%,
+    49% {
+        opacity: 1;
+    }
+    50%,
+    100% {
+        opacity: 0.25;
+    }
+}
+
+@keyframes panel-rise {
+    from {
+        opacity: 0;
+        transform: translateY(14px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/_sass/tables.scss
+++ b/_sass/tables.scss
@@ -1,34 +1,40 @@
 table {
-    margin: 15px 0;
-    border-collapse: collapse;
     width: 100%;
-    padding: 0;
+    border-collapse: collapse;
+    margin: 2rem 0;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.85rem;
+    overflow: hidden;
+    box-shadow: 0 18px 32px -26px var(--shadow-color);
 }
-table tr {
-    border-top: 1px solid #cccccc00;
-    background-color:#cccccc00;
-    margin: 0;
-    padding: 0;
+
+table thead {
+    background: rgba(255, 255, 255, 0.05);
 }
-table tr:nth-child(2n) {
-    background-color: #cccccc00;
+
+table th,
+table td {
+    padding: 0.75rem 0.95rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
-table tr th {
-    font-weight: bold;
-    border: 0px solid #cccccc00;
-    text-align: center;
-    margin: 0;
-    padding: 6px 13px;
+
+table th {
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-color);
 }
-table tr td {
-    border: 0px solid #cccccc00;
-    text-align: center;
-    margin: 0;
-    padding: 6px 13px;
+
+table tbody tr:nth-child(even) {
+    background: rgba(255, 255, 255, 0.03);
 }
-table tr th :first-child, table tr td :first-child {
-    margin: 0;
+
+table tbody tr:hover {
+    background: rgba(255, 255, 255, 0.06);
 }
-table tr th :last-child, table tr td :last-child {
-    margin: 0;
+
+table tr:last-child td {
+    border-bottom: none;
 }

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -1,30 +1,132 @@
 @import "vars";
 
 .content {
-    a:hover {
-        text-decoration: underline;
+    h1,
+    h2,
+    h3,
+    h4 {
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        margin: 2.4rem 0 1.25rem;
+        color: var(--text-color);
     }
-    ul > li {
-        margin: 5px 0 5px 0;
+
+    h1 {
+        font-size: clamp(1.9rem, 5vw, 2.5rem);
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        padding-bottom: 0.75rem;
+        position: relative;
     }
+
+    h1::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        width: 84px;
+        height: 3px;
+        background: linear-gradient(90deg, var(--accent-color), transparent);
+    }
+
+    h2 {
+        font-size: clamp(1.5rem, 4.5vw, 2rem);
+        padding-left: 1.1rem;
+        border-left: 4px solid var(--accent-color);
+        text-transform: none;
+    }
+
+    h3 {
+        font-size: clamp(1.25rem, 3.5vw, 1.6rem);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted-color);
+    }
+
+    h4 {
+        font-size: clamp(1.05rem, 3vw, 1.25rem);
+        text-transform: uppercase;
+        color: var(--muted-color);
+        letter-spacing: 0.14em;
+    }
+
+    p {
+        margin: 0 0 1.4rem;
+    }
+
+    p + p {
+        margin-top: 1.1rem;
+    }
+
+    strong {
+        color: var(--accent-color);
+    }
+
+    em {
+        color: var(--muted-color);
+    }
+
     ul {
-        padding: 0 20px 0 20px;;
+        list-style: none;
+        padding-left: 0;
+        margin: 0 0 1.5rem 0;
     }
+
+    ul > li {
+        position: relative;
+        padding-left: 1.6rem;
+        margin: 0.5rem 0;
+    }
+
+    ul > li::before {
+        content: "▸";
+        position: absolute;
+        left: 0;
+        top: 0.05rem;
+        color: var(--accent-color);
+    }
+
     ol {
-        padding: 0 0 0 30px;
+        margin: 0 0 1.5rem 1.6rem;
+        padding-left: 0;
     }
-    ol > li:before {
-        left: -30px;
-        font-weight:bold;
+
+    ol > li {
+        margin: 0.5rem 0;
     }
-    ol li::marker {
-        font-weight: bold;
+
+    li > ul,
+    li > ol {
+        margin-top: 0.5rem;
     }
+
     blockquote {
-        //border: 1px solid black;
-        border-left: 5px solid #333333;
-        margin: 20px 0 20px 0;
-        padding: 2px 8px 2px 8px;
+        border-left: 4px solid var(--accent-color);
+        padding: 0.85rem 1.75rem;
+        margin: 2rem 0;
+        background: rgba(0, 0, 0, 0.35);
+        color: var(--muted-color);
         font-style: italic;
+    }
+
+    img,
+    video,
+    iframe {
+        max-width: 100%;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 18px 36px -24px var(--shadow-color);
+    }
+
+    figure {
+        margin: 2.1rem 0;
+        text-align: center;
+    }
+
+    figcaption {
+        margin-top: 0.75rem;
+        font-size: 0.85rem;
+        color: var(--muted-color);
+        letter-spacing: 0.08em;
     }
 }

--- a/fr/ressources/corrections/insee_administrateur_externe_1990.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1990.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet de cette épreuve est manquant. Si vous l'avez, n'hésitez pas à me le <a href = "mailto:benjamin.gilbert@sciencespo.fr">transmettre</a>.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_1991.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1991.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet de cette épreuve est manquant. Si vous l'avez, n'hésitez pas à me le <a href = "mailto:benjamin.gilbert@sciencespo.fr">transmettre</a>.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_1992.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1992.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet de cette épreuve est manquant. Si vous l'avez, n'hésitez pas à me le <a href = "mailto:benjamin.gilbert@sciencespo.fr">transmettre</a>.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_1993.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1993.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_1993.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 
@@ -34,7 +34,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
         <ol type="a" start="1">
             <li>
                 Calculer l'intégrale \(\int_{0}^{+\infty} e^{-t} \mathrm{d}t\).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En évaluant directement l'intégrale, on a :
                     $$
                     \int_{0}^{+\infty} e^{-t} \mathrm{d} t = \lim_{b \rightarrow +\infty} \int_{0}^{b} e^{-t} \mathrm{d}t = \lim_{b \rightarrow +\infty} \left[ -e^{-t} \right]_{0}^{b} = \lim_{b \rightarrow +\infty} -e^{-b} - \left( -e^{-0} \right) = 1.
@@ -50,7 +50,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 0 < F_n(x) < \frac{e^{-x}}{x^{n+1}}
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     Dans la suite, on définit \( f : t \mapsto \frac{e^{-t}}{t^{n+1}} \). Il est clair qu'on a pour tout \( n\in\mathbb{N} \) et \( t>x>0 \) :
                     $$
                     0 < f(t) < \frac{e^{-t}}{x^{n+1}}
@@ -66,7 +66,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
             </li>
             <li>
                 Montrer que pour tout \(n \in \mathbb{N} \), la fonction \( F_n \) est deux fois dérivable sur \( \left] 0, +\infty \right[ \) et calculer sa dérivée \( F'_n \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     Par le théorème fondamental de l'analyse, en utilisant le résultat de convergence montré à la question précédente, on a pour tout \(n \in \mathbb{N} \) et pour tout \( x \in \left] 0, +\infty \right[ \) :
                     $$
                     F'_n(x) = \frac{\partial}{\partial x} F_n(x) = \frac{\partial}{\partial x} \int_{x}^{+\infty} f(t) \mathrm{d}t = - f(x) = - \frac{e^{-x}}{x^{n+1}}
@@ -86,7 +86,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 F_n(x) = \frac{e^{-x}}{x^{n+1}} - (n+1)F_{n+1}(x)
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On utilise une intégration par parties.
                     <br><br>
                     Pour ce faire, on s'appuie sur le résultat de convergence montré dans les questions précédentes et on note que :
@@ -115,7 +115,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 e^{x} F_0(x) = f_n(x) + (-1)^n n! e^{x} F_n(x)
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On établit la relation par récurrence sur \( n \in \mathbb{N} \).
                     <br><br>
                     <u>Initialisation</u>
@@ -151,7 +151,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 \lvert \varphi(x) - f_n(x) \rvert \leq \frac{n!}{x^{n+1}}
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En utilisant la majoration trouvée précédemment, on a pour \( x >0 \) et \( n \in \mathbb{N} \) :
                     $$
                     \begin{aligned}
@@ -164,7 +164,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
             </li>
             <li>
                 Déterminer les valeurs de \( n \) pour lesquelles \( \varepsilon_n = \frac{n!}{10^{n+1}} \) est minimal, et en déduire pour ces valeurs de \( n \) un majorant numérique de l'erreur conimise en prenant \( \ln(10) \) comme valeur approchée de \( \varphi(10) \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On note que pour tout \( n \in \mathbb{N} : \varepsilon > 0 \) et qu'on a :
                     $$
                     \frac{\varepsilon_{n+1}}{\varepsilon_{n}} = \frac{(n+1)!}{10^{n+2}} \times \frac{10^{n+1}}{n!} = \frac{n+1}{10}
@@ -193,7 +193,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 G_n(x) = n! \int_{x}^{+\infty} \frac{e^{-t}(t-x)^n}{t^{n+1}} \mathrm{d}t.
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On remarque que pour tout \( n\in\mathbb{N}, x>0 \) et \( t>x \) on a :
                     $$
                     0 \leq (t-x)^n \leq t^n
@@ -206,7 +206,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
             </li>
             <li>
                 Exprimer la fonction \( G_n \) comme combinaison linéaire des fonctions \( x \mapsto x^p F_p(x) \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On rappelle que, par la formule du binôme de Newton, pour tout \( n \in \mathbb{N}, x>0 \) et \( t \geq x \) on a :
                     $$
                     (t-x)^{n} = \sum_{k=0}^{n} \binom{n}{k} t^{k} (-x)^{n-k}
@@ -227,13 +227,13 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
             </li>
             <li>
                 Établir que la fonction \( G_n(x) \) est deux fois dérivable sur \( \left] 0, +\infty \right[ \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En s'appuyant sur les résultats de la partie précédente, la fonction \( G_n(x) \) est deux fois dérivables sur \( \left] 0, +\infty \right[ \) pour tout \( n\in \mathbb{N} \) en tant que combinaison linéaire de fonctions elles-mêmes deux fois dérivables sur \( \left] 0, +\infty \right[ \).
                 </p>
             </li>
             <li>
                 Justifier que pour \( n\geq 1 \), on a \( \sum_{p=0}^n (-1)^p \binom{n, p} = 0 \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     Par la formule du binôme de Newton, on a :
                     $$
                     \sum_{p=0}^{n} (-1)^{p} C_{n}^{p} = \sum_{p=0}^{n} \binom{n}{p} (-1)^{p} (1)^{n-p} = (-1+1)^{n} = 0
@@ -245,7 +245,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 G_n'(x) = -n n! \int_{x}^{+\infty} \frac{e^{-t}(t-x)^{n-1}}{t^{n+1}} \mathrm{d}t.
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En utilisant les résultats de la partie précédente, on a :
                     $$
                     \begin{aligned}
@@ -268,7 +268,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 xG_n'(x) = n G_n(x) - n^2 G_{n-1}(x).
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En utilisant les résultats précédents, on a pour tout \( n \geq 1 \) et pour tout \( x > 0 \) :
                     $$
                     \begin{aligned}
@@ -286,7 +286,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 G_n'(x) = n G_{n-1}(x) + n G_{n-1}'(x).
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On utilise une intégration par parties.
                     <br><br>
                     Pour ce faire, on note que :
@@ -321,7 +321,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 G_{n+1}(x) = (x+2n+1) G_n(x) - n^2 G_{n-1}(x).
                 $$
-                 <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                 <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En utilisant les résultats précédents, on a pour \( n\geq 1 \) et \( x > 0 \) :
                     $$
                     x G_{n+1}'(x) = x (n+1) G_{n}(x) + x(n+1) G_{n}'(x)
@@ -353,7 +353,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 x G_n''(x) + (x+1) G_n'(x) - nG_n(x) = 0.
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On note d'abord qu'on a pour tout \( n\geq 1 \) et \( x > 0 \), en combinant les résultats précédents :
                     $$
                     n G_{n}(x) = x G_n'(x) + n^{2} G_{n-1}(x) = x G_n'(x) + n \left( G_n'(x) - n G_{n-1}'(x)\right)
@@ -396,7 +396,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 (p+1)^2 \alpha_{n, p+1} = (n-p)\alpha_{n, p}
                 $$
                 où l'on a posé \( \alpha_{n, n} = 1 \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En dérivant, on note qu'on a pour tout \(n \geq 1 \) et \( x > 0 \) :
                     $$
                     P_{n}'(x) = \sum_{p=1}^{n} \alpha_{n, p} p x^{p-1}
@@ -429,7 +429,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
             </li>
             <li>
                 En déduire que \( \alpha_{n, p} = \frac{n!}{p!} \binom{n}{p} \) puis que \( \alpha_{n, p} \) est entier.
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En utilisant le résulat précédent, on peut écrire pour tout \( p \in \{ 0, ..., n-1\} \) :
                     $$
                     \alpha_{n, p} = \frac{(p+1)^{2}}{(n-p)} \alpha_{n, p+1}
@@ -452,7 +452,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
             </li>
             <li>
                 Expliciter les polynômes \( P_1, P_2 \) et \( P_3 \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On obtient les polynômes suivants :
                     <br><br>
                     • &nbsp; pour tout \( x > 0 \) : \( P_{1}(x)=x+1 \)
@@ -473,7 +473,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 <br>
                 Vérifier que \( Q_n(x) = \sum_{p=0}^n \alpha_{n, p} x^p f_p(x) \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On sait par les questions précédentes que pour tout \( n \in \mathbb{N} \) et \( x>0 \) on a :
                     $$
                     e^{x} F_{0}(x) = f_{n}(x) + (-1)^{n} n! e^{x} F_{n}(x)
@@ -491,7 +491,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
             </li>
             <li>
                 Expliciter les polynômes \( Q_1, Q_2 \) et \( Q_3 \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     On obtient les polynômes suivants :
                     <br><br>
                     • &nbsp; pour tout \( x > 0 \) : 
@@ -528,7 +528,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 $$
                 P_n(x) > n! n x.
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     \( G_n(x) \) étant définie comme une intégrale de fonctions strictement positives sur son intervalle d'intégration, on a nécessairement pour tout \( n\in \mathbb{N} \) et \( x > 0 \) : \( 0 < G_n(x) \).
                     <br><br>
                     On rappelle ensuite que : 
@@ -564,7 +564,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
             </li>
             <li>
                 Montrer que pour \( x > 0 \) fixé, on a \( \lim_{n \rightarrow +\infty} \frac{G_n(x)}{P_n(x)}e^x = 0 \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En notant que \( n\in \mathbb{N} \) et \( x > 0 \) : \( P_n(x) > 0 \) et \( G_n(x) > 0 \), on a pour \( x > 0 \) fixé :
                     $$
                     \lim_{n \rightarrow +\infty} \frac{G_n(x)}{P_n(x)} e^x \leq \lim_{n \rightarrow +\infty}  \frac{\frac{n! e^{-x}}{x} e^x}{n! n x} = \lim_{n \rightarrow +\infty} \frac{1}{nx^2} = 0
@@ -579,7 +579,7 @@ Dans tout le problème \( x \) désigne un réel <i>strictement positif</i>, et 
                 En déduire pour \( x > 0 \) fixé \( \varphi(x) = \lim_{n \rightarrow +\infty} \frac{Q_n(x)}{P_n(x)} \).
                 <br><br>
                 Puis, calculer \( \frac{Q_3(10)}{P_3(10)} \) et en dédurie une valeur approchée de \( \varphi(10) \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     En utilisant les résultats précédents, on note que pour tout \( n\in \mathbb{N} \) et \( x > 0 \) :
                     $$
                     \frac{G_n(x) e^x}{P_n(x)} = \frac{\left( P_n(x) F_0(x) - Q_n(x) e^{-x} \right) e^x}{P_n(x)} = F_0(x) e^x - \frac{Q_n(x)}{P_n(x)}
@@ -617,7 +617,7 @@ $$
         <ol type="a" start="1">
             <li>
                 Calculer \( A = \frac{1}{4}(M - I) \) puis \( A^2 \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
@@ -626,13 +626,13 @@ $$
                 $$
                 \forall n \in \mathbb{N} : M^n = I + u_n A
                 $$
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li>
                 Calculer \( u_n \) en fonction de \( n \) et en déduire l'expression de \( M^n \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
@@ -644,7 +644,7 @@ $$
         J = \begin{pmatrix} -1 & 0 & -2 \\ 1 & 1 & 1 \\ 1 & 0 & 2 \end{pmatrix}.
         $$
         Calculer \( J^2 \) puis \( J^n \) et montrer que \( J \) n'est pas inversible.
-        <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+        <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
             ...
         </p>
     </li>
@@ -655,13 +655,13 @@ $$
         <ol type="a" start="1">
             <li>
                 Montrer que \( E \) est stable par le produit de matrices. Montrer aussi que \( E \) est un espace vectoriel réel, en donner une base et préciser sa dimension.
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li>
                 Déterminer quels sont les éléments de \( E \) admettant un inverse dans \( E \), et préciser celui-ci.
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
@@ -671,7 +671,7 @@ $$
                 • &nbsp; \( X^2 = I \),
                 <br><br>
                 • &nbsp; \( X^2 = X \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
@@ -681,13 +681,13 @@ $$
         <ol type="a" start="1">
             <li>
                 Montrer que \( M \in E \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li>
                 En déduire que \( M^n = [1 - (-3)^n]J + (-3)^n I \) et comparer avec le résultat obtenu à la première question.
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
@@ -700,7 +700,7 @@ $$
         <ol type="a" start="1">
             <li>
                 Pour quelles valeurs de \(X\) le noyau de l'endomorphisme \(j - X I_{d}\) n'est-il pas réduit au vecteur nul ?
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
@@ -711,25 +711,25 @@ $$
                 $$
                 <br>
                 Déterminer la matrice de passage \(P\) de la base canonique à \(\mathcal{B}\).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li>
                 Donner dans la base \(\mathcal{B}\) la matrice \(N\) de l'endomorphisme \(f\) de matrice \(M\) dans la base canonique.
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li>
                 Déterminer la matrice de \(f^n = f \circ ... \circ f\) dans cette base.
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li>
                 Retrouver à nouveau l'expression de \( M^n \).
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>

--- a/fr/ressources/corrections/insee_administrateur_externe_1994.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1994.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet de cette épreuve est manquant. Si vous l'avez, n'hésitez pas à me le <a href = "mailto:benjamin.gilbert@sciencespo.fr">transmettre</a>.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_1995.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1995.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_1995.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_1996.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1996.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_1996.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_1997.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1997.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_1997.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_1998.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1998.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_1998.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_1999.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_1999.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_1999.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2000.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2000.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2000.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2001.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2001.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2001.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2002.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2002.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2002.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2003.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2003.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet de cette épreuve est manquant. Si vous l'avez, n'hésitez pas à me le <a href = "mailto:benjamin.gilbert@sciencespo.fr">transmettre</a>.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2004.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2004.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet de cette épreuve est manquant. Si vous l'avez, n'hésitez pas à me le <a href = "mailto:benjamin.gilbert@sciencespo.fr">transmettre</a>.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2005.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2005.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet de cette épreuve est manquant. Si vous l'avez, n'hésitez pas à me le <a href = "mailto:benjamin.gilbert@sciencespo.fr">transmettre</a>.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2006.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2006.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2006.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2007.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2007.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2007.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2008.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2008.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2008.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2009.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2009.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2009.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2010.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2010.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2010.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2011.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2011.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2011.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2012.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2012.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2012.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2013.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2013.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2013.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2014.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2014.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2014.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2015.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2015.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2015.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2016.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2016.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2016.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 
@@ -45,8 +45,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
         </p>
     
         <!-- Answer placeholder -->
-        <p style="border: solid 2px; border-radius: 10px; 
-                  background-color:rgba(152, 180, 212, .1); 
+        <p style="border: none; border-radius: 0; 
+                  background-color:rgba(152, 180, 212, .12); 
                   padding: 10px; margin: 15px 0 15px -30px;">
             Pour \(x&gt;0\), la fonction \(t\mapsto \dfrac{x\cos t}{x^{2}+t^{2}}\) est continue sur \([0,+\infty[\). <br>
             – Sur \([0,1]\), elle est bornée (en particulier \( \left|\dfrac{x\cos t}{x^{2}+t^{2}}\right| \le \dfrac{x}{x^{2}}=\dfrac1x\)), donc intégrable. <br>
@@ -75,8 +75,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     Pour \(b&gt;0\), on intègre par parties sur \([0,b]\) avec
                     \[
@@ -107,8 +107,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     D’après (a),
                     \[
@@ -133,8 +133,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     D’après (b), \(|h(x)|\le \dfrac{1}{x}\) pour tout \(x&gt;0\). Par encadrement,
                     \(\displaystyle \lim_{x\to +\infty}h(x)=0\).
@@ -159,8 +159,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     Dans la définition de \(h(x)\), on pose \(t=xu\) (avec \(u\in[0,+\infty[\)), donc \(\mathrm dt=x\,\mathrm du\).
                     Alors
@@ -182,8 +182,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     On a \(1-\cos a=2\sin^{2}\!\bigl(\tfrac{a}{2}\bigr)\ge 0\). De plus, pour tout \(u\in\mathbb R\),
                     \(|\sin u|\le |u|\) (par inégalité des accroissements finis appliquée à \(\sin\)).
@@ -208,8 +208,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     Par (3a), 
                     \[
@@ -242,8 +242,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     À partir de (3c), pour tout \(A&gt;0\) et \(x&gt;0\),
                     \[
@@ -283,8 +283,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     Posons \(s=x^{2}+t^{2}\). On a
                     \[
@@ -316,8 +316,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     On écrit
                     \[
@@ -361,8 +361,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     On a \((e^{x}h(x))'=e^{x}(h'(x)+h(x))\), donc
                     \[
@@ -384,8 +384,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
     
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     De (a), \(k'(x)=0\) donc \(k\) est constante : il existe \(C\in\mathbb R\) tel que
                     \[
@@ -423,8 +423,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
         </p>
 
         <!-- Answer placeholder -->
-        <p style="border: solid 2px; border-radius: 10px; 
-                  background-color:rgba(152, 180, 212, .1); 
+        <p style="border: none; border-radius: 0; 
+                  background-color:rgba(152, 180, 212, .12); 
                   padding: 10px; margin: 15px 0 15px -30px;">
             ...
         </p>
@@ -446,8 +446,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -463,8 +463,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -477,8 +477,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -502,8 +502,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -519,8 +519,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -539,8 +539,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -553,8 +553,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -583,8 +583,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -597,8 +597,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -621,8 +621,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -636,8 +636,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -675,8 +675,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
         </p>
 
         <!-- Answer placeholder -->
-        <p style="border: solid 2px; border-radius: 10px; 
-                  background-color:rgba(152, 180, 212, .1); 
+        <p style="border: none; border-radius: 0; 
+                  background-color:rgba(152, 180, 212, .12); 
                   padding: 10px; margin: 15px 0 15px -30px;">
             ...
         </p>
@@ -702,8 +702,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -716,8 +716,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -744,8 +744,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
         </p>
 
         <!-- Answer placeholder -->
-        <p style="border: solid 2px; border-radius: 10px; 
-                  background-color:rgba(152, 180, 212, .1); 
+        <p style="border: none; border-radius: 0; 
+                  background-color:rgba(152, 180, 212, .12); 
                   padding: 10px; margin: 15px 0 15px -30px;">
             ...
         </p>
@@ -766,8 +766,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
         </p>
 
         <!-- Answer placeholder -->
-        <p style="border: solid 2px; border-radius: 10px; 
-                  background-color:rgba(152, 180, 212, .1); 
+        <p style="border: none; border-radius: 0; 
+                  background-color:rgba(152, 180, 212, .12); 
                   padding: 10px; margin: 15px 0 15px -30px;">
             ...
         </p>
@@ -789,8 +789,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
         </p>
 
         <!-- Answer placeholder -->
-        <p style="border: solid 2px; border-radius: 10px; 
-                  background-color:rgba(152, 180, 212, .1); 
+        <p style="border: none; border-radius: 0; 
+                  background-color:rgba(152, 180, 212, .12); 
                   padding: 10px; margin: 15px 0 15px -30px;">
             ...
         </p>
@@ -806,8 +806,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -819,8 +819,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -842,8 +842,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -854,8 +854,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -897,8 +897,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -918,8 +918,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -957,8 +957,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -977,8 +977,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                         <p>Montrer que l’intégrale \(J_{n}\) est convergente.</p>
 
                         <!-- Answer placeholder -->
-                        <p style="border: solid 2px; border-radius: 10px; 
-                                  background-color:rgba(152, 180, 212, .1); 
+                        <p style="border: none; border-radius: 0; 
+                                  background-color:rgba(152, 180, 212, .12); 
                                   padding: 10px; margin: 15px 0 15px -60px;">
                             ...
                         </p>
@@ -987,8 +987,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                         <p>En déduire que \(S_{n}\) admet une espérance mathématique.</p>
 
                         <!-- Answer placeholder -->
-                        <p style="border: solid 2px; border-radius: 10px; 
-                                  background-color:rgba(152, 180, 212, .1); 
+                        <p style="border: none; border-radius: 0; 
+                                  background-color:rgba(152, 180, 212, .12); 
                                   padding: 10px; margin: 15px 0 15px -60px;">
                             ...
                         </p>
@@ -1017,8 +1017,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1031,8 +1031,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1046,8 +1046,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1081,8 +1081,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1094,8 +1094,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1107,8 +1107,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1155,8 +1155,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1168,8 +1168,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1191,8 +1191,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1204,8 +1204,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1216,8 +1216,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1235,8 +1235,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
         </p>
 
         <!-- Answer placeholder -->
-        <p style="border: solid 2px; border-radius: 10px; 
-                  background-color:rgba(152, 180, 212, .1); 
+        <p style="border: none; border-radius: 0; 
+                  background-color:rgba(152, 180, 212, .12); 
                   padding: 10px; margin: 15px 0 15px -30px;">
             ...
         </p>
@@ -1270,8 +1270,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 $$
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1284,8 +1284,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1297,8 +1297,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1313,8 +1313,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
                 </p>
 
                 <!-- Answer placeholder -->
-                <p style="border: solid 2px; border-radius: 10px; 
-                          background-color:rgba(152, 180, 212, .1); 
+                <p style="border: none; border-radius: 0; 
+                          background-color:rgba(152, 180, 212, .12); 
                           padding: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
@@ -1333,8 +1333,8 @@ On note \(J\) l’intervalle \(\left] 0,+\infty \right[\) et on définit sur \(J
         </p>
 
         <!-- Answer placeholder -->
-        <p style="border: solid 2px; border-radius: 10px; 
-                  background-color:rgba(152, 180, 212, .1); 
+        <p style="border: none; border-radius: 0; 
+                  background-color:rgba(152, 180, 212, .12); 
                   padding: 10px; margin: 15px 0 15px -30px;">
             ...
         </p>

--- a/fr/ressources/corrections/insee_administrateur_externe_2017.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2017.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2017.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2018.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2018.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2018.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2019.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2019.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2019.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2020.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2020.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2020.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2021.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2021.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2021.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2022.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2022.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2022.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 

--- a/fr/ressources/corrections/insee_administrateur_externe_2023.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2023.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2023.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 
@@ -37,19 +37,19 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -59,19 +59,19 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -81,19 +81,19 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -103,13 +103,13 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -117,7 +117,7 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                 </p>
     </li>
@@ -125,31 +125,31 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -157,7 +157,7 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                 </p>
     </li>
@@ -165,7 +165,7 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
@@ -173,7 +173,7 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                 </p>
     </li>
@@ -184,19 +184,19 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
 <ol type="1" start="1">
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                 </p>
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                 </p>
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                 </p>
     </li>
@@ -204,19 +204,19 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -226,13 +226,13 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -240,13 +240,13 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                 </p>
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                 </p>
     </li>
@@ -267,25 +267,25 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -293,7 +293,7 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                 </p>
     </li>
@@ -301,19 +301,19 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -323,19 +323,19 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -345,19 +345,19 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -372,13 +372,13 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -386,7 +386,7 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                  </p>
     </li>
@@ -394,13 +394,13 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
         <ol type="a" start="1">
             <li>
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                 </p>
             </li>
             <li> 
                 ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -60px;">
                     ...
                  </p>
             </li>
@@ -408,19 +408,19 @@ Les propositions de corrections présentées ci-dessous n'engagent que l'auteur 
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                  </p>
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                  </p>
     </li>
     <li>
         ...
-                <p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
+                <p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px -30px;">
                     ...
                  </p>
     </li>

--- a/fr/ressources/corrections/insee_administrateur_externe_2024.md
+++ b/fr/ressources/corrections/insee_administrateur_externe_2024.md
@@ -15,7 +15,7 @@ katex: True
 Le sujet est accessible <a href = "/pdfs/insee_administrateur_externe/insee_administrateur_externe_2024.pdf">ici</a> au format PDF.
 </p>
 
-<p style="border: solid 2px; border-radius: 10px; background-color:rgba(152, 180, 212, .1); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
+<p style="border: none; border-radius: 0; background-color:rgba(152, 180, 212, .12); padding-right: 10px; padding-left: 10px; padding-top: 10px; padding-bottom: 10px; margin: 15px 0 15px 0px;">
 Les propositions de corrections présentées ci-dessous n'engagent que l'auteur de ce site.
 </p>
 


### PR DESCRIPTION
## Summary
- retune the light theme palette to a solarized-inspired scheme and drop the brand separator for a cleaner prompt
- increase default paragraph spacing for easier reading
- flatten the correction callout blocks across all math resources to remove borders and rounded corners

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d692b61e308324bd0701472617af6f